### PR TITLE
Detect if response is JSON before parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@imaginelearning/httprx",
 	"author": "Imagine Learning",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"license": "MIT",
 	"main": "dist/index.js",
 	"module": "dist/httprx.esm.js",

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -463,12 +463,22 @@ describe('Http', () => {
 			fetchMock.resetMocks();
 		});
 
-		it('returns properly parsed JSON', done => {
+		it('returns properly parsed JSON for object', done => {
 			fetchMock.once('{"hello":"world"}');
 			http(baseUrl)
 				.get<{ hello: string }>()
 				.subscribe(({ data: { hello } }) => {
 					expect(hello).toEqual('world');
+					done();
+				}, done.fail);
+		});
+
+		it('returns properly parsed JSON for array', done => {
+			fetchMock.once('["hello", "world"]');
+			http(baseUrl)
+				.get<{ hello: string }>()
+				.subscribe(({ data }) => {
+					expect(data).toEqual(['hello', 'world']);
 					done();
 				}, done.fail);
 		});
@@ -479,6 +489,16 @@ describe('Http', () => {
 				.get<string>()
 				.subscribe(({ data }) => {
 					expect(data).toBe('hello world');
+					done();
+				}, done.fail);
+		});
+
+		it('handles error parsing JSON', done => {
+			fetchMock.once('{"hello":"world"');
+			http(baseUrl)
+				.get<string>()
+				.subscribe(({ data }) => {
+					expect(data).toBe('{"hello":"world"');
 					done();
 				}, done.fail);
 		});

--- a/src/http.ts
+++ b/src/http.ts
@@ -235,11 +235,12 @@ function httpRequest<T>(url: string, options?: RequestInit) {
 				}
 				throw error;
 			}
-
 			const text = await response.text();
+			const isJson = !!text && (text[0] === '{' || text[0] === '[');
 			let data: T;
 			try {
-				data = JSON.parse(text) as T;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data = (isJson ? JSON.parse(text) : (text as any)) as T;
 			} catch {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				data = (text as any) as T;


### PR DESCRIPTION
Rather than always try to parse the response as JSON, do a quick and dirty check if it starts with `{` or `[`. It still includes error handling in case the response contains invalid JSON.